### PR TITLE
checking undefined instead of falsy

### DIFF
--- a/NumericInput/NumericInput.js
+++ b/NumericInput/NumericInput.js
@@ -122,7 +122,7 @@ export default class NumericInput extends Component {
 
     render() {
         const editable = this.props.editable
-        const sepratorWidth = this.props.sepratorWidth || this.props.separatorWidth
+        const sepratorWidth =  (typeof this.props.separatorWidth === 'undefined') ? this.props.sepratorWidth : this.props.separatorWidth;//supporting old property name sepratorWidth
         const iconSize = this.props.iconSize
         const borderColor = this.props.borderColor
         const iconStyle = [style.icon, this.props.iconStyle]


### PR DESCRIPTION
Sorry for submitting without properly testing the code.
 
In the previous change, `this.props.sepratorWidth || this.props.separatorWidth`, first part will never be false, as it is set to 1 in default props. Also, the || operator fails if the value was explicitly set to zero.

Now the component will take the correctly spelled property name, if not set, falls back to older property name which is used in default props.
Have tested it with both the props, with the correct name overriding the typo and omitting the correct name falling back to the old prop name.