### PR TITLE
Fix the version of react-native-vector-icons module

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "react-native-pixel-perfect": "^1.0.1"
   },
   "peerDependencies": {
-    "react-native-vector-icons": "^4.*"
+    "react-native-vector-icons": "^9.*"
   }
 }


### PR DESCRIPTION
This fix is required to run the module in recent react native versions