### PR TITLE
not changing local state when parsed value is the same of the previous

### DIFF
--- a/NumericInput/NumericInput.js
+++ b/NumericInput/NumericInput.js
@@ -115,10 +115,10 @@ export default class NumericInput extends Component {
             this.setState({ stringValue: value })
             let parsedValue = this.props.valueType === 'real' ? parseFloat(value) : parseInt(value)
             parsedValue = isNaN(parsedValue) ? 0 : parsedValue
-            if (parsedValue !== this.props.value)
-                this.props.onChange && this.props.onChange(parsedValue)
-            this.setState({ value: parsedValue, legal, stringValue: parsedValue.toString() })
-
+            if (parsedValue !== this.props.value) {
+                this.props.onChange && this.props.onChange(parsedValue, value)
+                this.setState({ value: parsedValue, legal, stringValue: parsedValue.toString() })
+            }
         }
     }
     onBlur = () => {


### PR DESCRIPTION
we did this small change to allow user input number like 0.01, with the current implementation this is not possible as 0.00 would be resetted to 0.
Since 1.01 is equal to 1.0100 just skipping the state update when the real values are the same is enough.
In addition I forwarded the original text to the change handler as second parameter, this may be useful for additional logic and would not impact the currents implementations that expect a real number as first parameter of the onChange