### PR TITLE
Fix issue95 no minus sign keyboard on iOS

### DIFF
--- a/NumericInput/NumericInput.js
+++ b/NumericInput/NumericInput.js
@@ -127,10 +127,10 @@ export default class NumericInput extends Component {
         let legal = match && match[0] === match.input && ((this.props.maxValue === null || (parseFloat(this.state.stringValue) <= this.props.maxValue)) && (this.props.minValue === null || (parseFloat(this.state.stringValue) >= this.props.minValue)))
         if (!legal) {
             if (this.props.minValue !== null && (parseFloat(this.state.stringValue) <= this.props.minValue)) {
-                this.props.onLimitReached(true, 'Reached Minimum Value!')
+                this.props.onLimitReached(false, 'Reached Minimum Value!')
             }
             if (this.props.maxValue !== null && (parseFloat(this.state.stringValue) >= this.props.maxValue)) {
-                this.props.onLimitReached(false, 'Reached Maximum Value!')
+                this.props.onLimitReached(true, 'Reached Maximum Value!')
             }
             if (this.ref) {
                 this.ref.blur()

--- a/NumericInput/NumericInput.js
+++ b/NumericInput/NumericInput.js
@@ -71,6 +71,7 @@ export default class NumericInput extends Component {
     intMatch = (value) => value && value.match(/-?\d+/) && value.match(/-?\d+/)[0] === value.match(/-?\d+/).input
 
     onChange = (value) => {
+        value = value.replace(",", ".");
         let currValue = typeof this.props.value === 'number' ? this.props.value : this.state.value
         if ((value.length === 1 && value === '-') || (value.length === 2 && value === '0-')) {
             this.setState({ stringValue: '-' })

--- a/NumericInput/NumericInput.js
+++ b/NumericInput/NumericInput.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { View, TextInput, StyleSheet, Text } from 'react-native'
+import { View, TextInput, StyleSheet, Text, Platform } from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import Button from '../Button'
 import PropTypes from 'prop-types'
@@ -219,7 +219,7 @@ export default class NumericInput extends Component {
         if (this.props.type === 'up-down')
             return (
                 <View style={inputContainerStyle}>
-                    <TextInput {...this.props.extraTextInputProps} editable={editable} returnKeyType='done' underlineColorAndroid='rgba(0,0,0,0)' keyboardType='numeric' value={this.state.stringValue} onChangeText={this.onChange} style={inputStyle} ref={ref => this.ref = ref} onBlur={this.onBlur} onFocus={this.onFocus} />
+                    <TextInput {...this.props.extraTextInputProps} editable={editable} returnKeyType='done' underlineColorAndroid='rgba(0,0,0,0)' keyboardType={Platform.OS === 'ios' ? 'numbers-and-punctuation' : 'numeric'} value={this.state.stringValue} onChangeText={this.onChange} style={inputStyle} ref={ref => this.ref = ref} onBlur={this.onBlur} onFocus={this.onFocus} />
                     <View style={upDownStyle}>
                         <Button onPress={this.inc} style={{ flex: 1, width: '100%', alignItems: 'center' }}>
                             <Icon name='ios-arrow-up' size={fontSize} style={[...iconStyle, maxReached ? this.props.reachMaxIncIconStyle : {}, minReached ? this.props.reachMinIncIconStyle : {}]} />
@@ -235,7 +235,7 @@ export default class NumericInput extends Component {
                     <Icon name='md-remove' size={fontSize} style={[...iconStyle, maxReached ? this.props.reachMaxDecIconStyle : {}, minReached ? this.props.reachMinDecIconStyle : {}]} />
                 </Button>
                 <View style={[inputWraperStyle]}>
-                    <TextInput {...this.props.extraTextInputProps} editable={editable} returnKeyType='done' underlineColorAndroid='rgba(0,0,0,0)' keyboardType='numeric' value={this.state.stringValue} onChangeText={this.onChange} style={inputStyle} ref={ref => this.ref = ref} onBlur={this.onBlur} onFocus={this.onFocus} />
+                    <TextInput {...this.props.extraTextInputProps} editable={editable} returnKeyType='done' underlineColorAndroid='rgba(0,0,0,0)' keyboardType={Platform.OS === 'ios' ? 'numbers-and-punctuation' : 'numeric'} value={this.state.stringValue} onChangeText={this.onChange} style={inputStyle} ref={ref => this.ref = ref} onBlur={this.onBlur} onFocus={this.onFocus} />
                 </View>
                 <Button onPress={this.inc} style={rightButtonStyle}>
                     <Icon name='md-add' size={fontSize} style={[...iconStyle, maxReached ? this.props.reachMaxIncIconStyle : {}, minReached ? this.props.reachMinIncIconStyle : {}]} />


### PR DESCRIPTION
changed the keyboard type to numbers-and-punctuation for iOS to include the "-" sign for typing negative numbers and added support for the "," symbol to act as the "." symbol